### PR TITLE
Improved schema validation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,4 @@ gemspec
 
 gem "rake", "~> 12.0"
 gem "minitest", "~> 5.0"
-gem "steep"
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     rbs_json_schema (0.1.0)
       activesupport (>= 5.0.0)
-      rbs (>= 1.5.0)
+      rbs (>= 1.8.0)
 
 GEM
   remote: https://rubygems.org/
@@ -14,39 +14,14 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
-    ast (2.4.2)
     concurrent-ruby (1.1.9)
-    ffi (1.15.3)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
-    language_server-protocol (3.16.0.3)
-    listen (3.7.0)
-      rb-fsevent (~> 0.10, >= 0.10.3)
-      rb-inotify (~> 0.9, >= 0.9.10)
     minitest (5.14.4)
-    parallel (1.20.1)
-    parser (3.0.2.0)
-      ast (~> 2.4.1)
-    rainbow (3.0.0)
     rake (12.3.3)
-    rb-fsevent (0.11.0)
-    rb-inotify (0.10.1)
-      ffi (~> 1.0)
-    rbs (1.5.1)
-    steep (0.46.0)
-      activesupport (>= 5.1)
-      language_server-protocol (>= 3.15, < 4.0)
-      listen (~> 3.0)
-      parallel (>= 1.0.0)
-      parser (>= 3.0)
-      rainbow (>= 2.2.2, < 4.0)
-      rbs (>= 1.2.0)
-      terminal-table (>= 2, < 4)
-    terminal-table (3.0.1)
-      unicode-display_width (>= 1.1.1, < 3)
+    rbs (1.8.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
-    unicode-display_width (2.0.0)
     zeitwerk (2.4.2)
 
 PLATFORMS
@@ -56,7 +31,6 @@ DEPENDENCIES
   minitest (~> 5.0)
   rake (~> 12.0)
   rbs_json_schema!
-  steep
 
 BUNDLED WITH
    2.2.22

--- a/bin/steep
+++ b/bin/steep
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+REPO_ROOT=$(cd $(dirname $0); pwd)
+GEMFILE=${REPO_ROOT}/../steep/Gemfile
+
+STEEP="bundle exec --gemfile=${GEMFILE} steep"
+
+if type "rbenv" > /dev/null 2>&1; then
+  STEEP="rbenv exec ${STEEP}"
+else
+  if type "rvm" > /dev/null 2>&1; then
+    STEEP="rvm ${REPO_ROOT} do ${STEEP}"
+  fi
+fi
+
+exec $STEEP $*
+

--- a/lib/rbs_json_schema/generator.rb
+++ b/lib/rbs_json_schema/generator.rb
@@ -26,7 +26,7 @@ module RBSJsonSchema
 
       @path_decls[uri.path] ||= RBS::AST::Declarations::Module.new(
         name: generate_type_name_for_uri(uri, module_name: true),
-        type_params: RBS::AST::Declarations::ModuleTypeParams.empty,
+        type_params: [],
         members: [],
         self_types: [],
         annotations: [],
@@ -40,13 +40,13 @@ module RBSJsonSchema
     def generate_rbs(uri, document)
       # If schema is already generated for a URI, do not re-generate declarations/types
       if fragment = uri.fragment
-        # return if fragment.empty? # If fragment is empty, implies top level schema which is always generated since it is the starting point of the algorithm
-
-        if @generated_schemas.dig(uri.path, fragment.empty? ? "#" : fragment) # Check if types have been generated for a particular path & fragment
+        # Check if types have been generated for a particular path & fragment
+        if @generated_schemas.dig(uri.path, fragment.empty? ? "#" : fragment)
           return
         end
       else
-        if @generated_schemas.dig(uri.path, "#") # Check if types have been generated for a particular path
+        # Check if types have been generated for a particular path
+        if @generated_schemas.dig(uri.path, "#")
           return
         end
       end
@@ -61,21 +61,24 @@ module RBSJsonSchema
       else
         @generated_schemas[uri.path]["#"] = true
       end
+
       # Parse & generate declarations from remaining schema content
       decl = Alias.new(
         name: generate_type_name_for_uri(uri), # Normal type name with no prefix
         type: translate_type(uri, document), # Obtain type of alias by parsing the schema document
+        type_params: [],
         annotations: [],
         location: nil,
         comment: nil
       )
+
       # Append the declaration if & only if the declaration has a valid RBS::Type assigned
       if @path_decls[uri.path]
         @path_decls[uri.path].members << decl if !decl.type.nil?
       else
         @path_decls[uri.path] = RBS::AST::Declarations::Module.new(
           name: generate_type_name_for_uri(uri, module_name: true),
-          type_params: RBS::AST::Declarations::ModuleTypeParams.empty,
+          type_params: [],
           members: [],
           self_types: [],
           annotations: [],
@@ -184,13 +187,15 @@ module RBSJsonSchema
             raise ValidationError.new(message: "Invalid URI encountered in: $ref = #{ref}")
           end
 
-        resolved_uri = resolve_uri(uri, ref_uri) # Resolve `$ref` URI with respect to current URI
+        # Resolve `$ref` URI with respect to current URI
+        resolved_uri = resolve_uri(uri, ref_uri)
         # Generate AST::Declarations::Alias
         generate_rbs(resolved_uri, read_from_uri(resolved_uri))
 
         # Assign alias type with appropriate namespace
         RBS::Types::Alias.new(
           name: generate_type_name_for_uri(resolved_uri, namespace: resolved_uri.path != uri.path),
+          args: []
           location: nil
         )
       else

--- a/lib/rbs_json_schema/generator.rb
+++ b/lib/rbs_json_schema/generator.rb
@@ -195,7 +195,7 @@ module RBSJsonSchema
         # Assign alias type with appropriate namespace
         RBS::Types::Alias.new(
           name: generate_type_name_for_uri(resolved_uri, namespace: resolved_uri.path != uri.path),
-          args: []
+          args: [],
           location: nil
         )
       else

--- a/rbs_json_schema.gemspec
+++ b/rbs_json_schema.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.description   = %q{Generate RBS type definitions from JSON Schema}
   spec.homepage      = "https://github.com/ruby/rbs_json_schema"
   spec.license       = "MIT"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.6.0")
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/ruby/rbs_json_schema"
@@ -25,6 +25,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "rbs", ">=1.5.0"
+  spec.add_runtime_dependency "rbs", ">=1.8.0"
   spec.add_runtime_dependency "activesupport", ">=5.0.0"
 end

--- a/steep/Gemfile
+++ b/steep/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "steep"
+

--- a/steep/Gemfile.lock
+++ b/steep/Gemfile.lock
@@ -1,0 +1,49 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (7.0.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+    ast (2.4.2)
+    concurrent-ruby (1.1.9)
+    ffi (1.15.5)
+    i18n (1.9.1)
+      concurrent-ruby (~> 1.0)
+    language_server-protocol (3.16.0.3)
+    listen (3.7.1)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    minitest (5.15.0)
+    parallel (1.21.0)
+    parser (3.1.0.0)
+      ast (~> 2.4.1)
+    rainbow (3.1.1)
+    rb-fsevent (0.11.0)
+    rb-inotify (0.10.1)
+      ffi (~> 1.0)
+    rbs (1.7.1)
+    steep (0.47.0)
+      activesupport (>= 5.1)
+      language_server-protocol (>= 3.15, < 4.0)
+      listen (~> 3.0)
+      parallel (>= 1.0.0)
+      parser (>= 3.0)
+      rainbow (>= 2.2.2, < 4.0)
+      rbs (~> 1.7.0)
+      terminal-table (>= 2, < 4)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
+    tzinfo (2.0.4)
+      concurrent-ruby (~> 1.0)
+    unicode-display_width (2.1.0)
+
+PLATFORMS
+  x86_64-linux
+
+DEPENDENCIES
+  steep
+
+BUNDLED WITH
+   2.2.22

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -34,7 +34,7 @@ module Location
 
   type definitions_buffer = { name: ::String | nil }
 
-  type definitions_location = { start: definitions_point, :end => definitions_point, buffer: definitions_buffer }
+  type definitions_location = { start: definitions_point, end: definitions_point, buffer: definitions_buffer }
 
   type t = definitions_location | nil
 end
@@ -45,13 +45,13 @@ end
       cli.run(%W(--no-stringify-keys ./schema/decls.json))
       assert_equal <<-EOF, stdout.string
 module Decls
-  type definitions_alias = { declaration: "alias", name: ::String, :type => Types::t, annotations: ::Array[Annotation::t], location: Location::t, comment: Comment::t }
-
-  type definitions_constant = { declaration: "constant", name: ::String, :type => Types::t, location: Location::t, comment: Comment::t }
-
-  type definitions_global = { declaration: "global", name: ::String, :type => Types::t, location: Location::t, comment: Comment::t }
-
   type definitions_moduletypeparam = { name: ::String, variance: "covariant" | "contravariant" | "invariant", skip_validation: bool }
+
+  type definitions_alias = { declaration: "alias", name: ::String, type_params: { params: ::Array[definitions_moduletypeparam] }, type: Types::t, annotations: ::Array[Annotation::t], location: Location::t, comment: Comment::t }
+
+  type definitions_constant = { declaration: "constant", name: ::String, type: Types::t, location: Location::t, comment: Comment::t }
+
+  type definitions_global = { declaration: "global", name: ::String, type: Types::t, location: Location::t, comment: Comment::t }
 
   type definitions_moduleself = { name: ::String, args: ::Array[Types::t] }
 
@@ -63,7 +63,7 @@ module Decls
 
   type definitions_classmember = Members::definitions_methoddefinition | Members::definitions_variable | Members::definitions_include | Members::definitions_extend | Members::definitions_prepend | Members::definitions_attribute | Members::definitions_visibility | Members::definitions_alias | definitions_alias | definitions_constant | definitions_class | definitions_module | definitions_interface
 
-  type definitions_class = { declaration: "class", name: ::String, type_params: { params: ::Array[definitions_moduletypeparam] }, members: ::Array[definitions_classmember], :super_class => nil | { name: ::String, args: ::Array[Types::t] }, annotations: ::Array[Annotation::t], comment: Comment::t, location: Location::t }
+  type definitions_class = { declaration: "class", name: ::String, type_params: { params: ::Array[definitions_moduletypeparam] }, members: ::Array[definitions_classmember], super_class: nil | { name: ::String, args: ::Array[Types::t] }, annotations: ::Array[Annotation::t], comment: Comment::t, location: Location::t }
 
   type t = definitions_alias | definitions_constant | definitions_global | definitions_class | definitions_module | definitions_interface
 end
@@ -73,45 +73,45 @@ module Location
 
   type definitions_buffer = { name: ::String | nil }
 
-  type definitions_location = { start: definitions_point, :end => definitions_point, buffer: definitions_buffer }
+  type definitions_location = { start: definitions_point, end: definitions_point, buffer: definitions_buffer }
 
   type t = definitions_location | nil
 end
 
 module Types
-  type definitions_base = { :class => "bool" | "void" | "untyped" | "nil" | "top" | "bot" | "self" | "instance" | "class", location: Location::t }
+  type definitions_base = { class: "bool" | "void" | "untyped" | "nil" | "top" | "bot" | "self" | "instance" | "class", location: Location::t }
 
-  type definitions_variable = { :class => "variable", name: ::String, location: Location::t }
+  type definitions_variable = { class: "variable", name: ::String, location: Location::t }
 
-  type definitions_classinstance = { :class => "class_instance", name: ::String, args: ::Array[t], location: Location::t }
+  type definitions_classinstance = { class: "class_instance", name: ::String, args: ::Array[t], location: Location::t }
 
-  type definitions_classsingleton = { :class => "class_singleton", name: ::String, location: Location::t }
+  type definitions_classsingleton = { class: "class_singleton", name: ::String, location: Location::t }
 
-  type definitions_interface = { :class => "interface", name: ::String, args: ::Array[t], location: Location::t }
+  type definitions_interface = { class: "interface", name: ::String, args: ::Array[t], location: Location::t }
 
-  type definitions_alias = { :class => "alias", name: ::String, location: Location::t }
+  type definitions_alias = { class: "alias", name: ::String, args: ::Array[t], location: Location::t }
 
-  type definitions_tuple = { :class => "tuple", types: ::Array[t], location: Location::t }
+  type definitions_tuple = { class: "tuple", types: ::Array[t], location: Location::t }
 
-  type definitions_record = { :class => "record", fields: ::Hash[::String, t], location: Location::t }
+  type definitions_record = { class: "record", fields: ::Hash[::String, t], location: Location::t }
 
-  type definitions_union = { :class => "union", types: ::Array[t], location: Location::t }
+  type definitions_union = { class: "union", types: ::Array[t], location: Location::t }
 
-  type definitions_intersection = { :class => "intersection", types: ::Array[t], location: Location::t }
+  type definitions_intersection = { class: "intersection", types: ::Array[t], location: Location::t }
 
-  type definitions_optional = { :class => "optional", :type => t, location: Location::t }
+  type definitions_optional = { class: "optional", type: t, location: Location::t }
 
-  type definitions_proc = { :class => "proc", :type => Function::t, location: Location::t }
+  type definitions_proc = { class: "proc", type: Function::t, location: Location::t }
 
-  type definitions_literal = { :class => "literal", literal: ::String, location: Location::t }
+  type definitions_literal = { class: "literal", literal: ::String, location: Location::t }
 
   type t = definitions_base | definitions_variable | definitions_classinstance | definitions_classsingleton | definitions_interface | definitions_alias | definitions_tuple | definitions_record | definitions_union | definitions_intersection | definitions_optional | definitions_proc | definitions_literal
 end
 
 module Function
-  type definitions_param = { :type => Types::t, name: ::String | nil }
+  type definitions_param = { type: Types::t, name: ::String | nil }
 
-  type t = { required_positionals: ::Array[definitions_param], optional_positionals: ::Array[definitions_param], rest_positionals: definitions_param | nil, trailing_positionals: ::Array[definitions_param], required_keywords: ::Hash[::String, definitions_param], optional_keywords: ::Hash[::String, definitions_param], rest_keywords: definitions_param | nil, :return_type => Types::t }
+  type t = { required_positionals: ::Array[definitions_param], optional_positionals: ::Array[definitions_param], rest_positionals: definitions_param | nil, trailing_positionals: ::Array[definitions_param], required_keywords: ::Hash[::String, definitions_param], optional_keywords: ::Hash[::String, definitions_param], rest_keywords: definitions_param | nil, return_type: Types::t }
 end
 
 module Annotation
@@ -125,15 +125,15 @@ module Comment
 end
 
 module MethodType
-  type definitions_block = { :type => Function::t, required: bool }
+  type definitions_block = { type: Function::t, required: bool }
 
-  type t = { type_params: ::Array[::String], :type => Function::t, block: definitions_block | nil, location: Location::t }
+  type t = { type_params: ::Array[::String], type: Function::t, block: definitions_block | nil, location: Location::t }
 end
 
 module Members
-  type definitions_methoddefinition = { member: "method_definition", kind: "instance" | "singleton" | "singleton_instance", types: ::Array[MethodType::t], comment: Comment::t, annotations: ::Array[Annotation::t], attributes: ::Array["incompatible"], location: Location::t, :overload => bool }
+  type definitions_methoddefinition = { member: "method_definition", kind: "instance" | "singleton" | "singleton_instance", types: ::Array[MethodType::t], comment: Comment::t, annotations: ::Array[Annotation::t], attributes: ::Array["incompatible"], location: Location::t, overload: bool }
 
-  type definitions_variable = { member: "instance_variable" | "class_instance_variable" | "class_variable", name: ::String, :type => Types::t, location: Location::t, comment: Comment::t }
+  type definitions_variable = { member: "instance_variable" | "class_instance_variable" | "class_variable", name: ::String, type: Types::t, location: Location::t, comment: Comment::t }
 
   type definitions_include = { member: "include", name: ::String, args: ::Array[Types::t], annotations: ::Array[Annotation::t], comment: Comment::t, location: Location::t }
 
@@ -141,7 +141,7 @@ module Members
 
   type definitions_prepend = { member: "prepend", name: ::String, args: ::Array[Types::t], annotations: ::Array[Annotation::t], comment: Comment::t, location: Location::t }
 
-  type definitions_attribute = { member: "attr_reader" | "attr_accessor" | "attr_writer", name: ::String, kind: "instance" | "singleton", :type => Types::t, ivar_name: ::String | nil | false, annotations: ::Array[Annotation::t], comment: Comment::t, location: Location::t }
+  type definitions_attribute = { member: "attr_reader" | "attr_accessor" | "attr_writer", name: ::String, kind: "instance" | "singleton", type: Types::t, ivar_name: ::String | nil | false, annotations: ::Array[Annotation::t], comment: Comment::t, location: Location::t }
 
   type definitions_visibility = { member: "public" | "private", location: Location::t }
 

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -6,6 +6,7 @@ class CLITest < Minitest::Test
   include RBSJsonSchema
 
   RBS_PATH = Pathname(Gem::Specification.find_by_name("rbs", RBS::VERSION).gem_dir).realpath
+  puts RBS_PATH
   SCHEMA_PATH = RBS_PATH + "schema"
 
   def stdout
@@ -34,7 +35,7 @@ module Location
 
   type definitions_buffer = { name: ::String | nil }
 
-  type definitions_location = { start: definitions_point, :end => definitions_point, buffer: definitions_buffer }
+  type definitions_location = { start: definitions_point, end: definitions_point, buffer: definitions_buffer }
 
   type t = definitions_location | nil
 end
@@ -45,13 +46,13 @@ end
       cli.run(%W(--no-stringify-keys ./schema/decls.json))
       assert_equal <<-EOF, stdout.string
 module Decls
-  type definitions_alias = { declaration: "alias", name: ::String, :type => Types::t, annotations: ::Array[Annotation::t], location: Location::t, comment: Comment::t }
-
-  type definitions_constant = { declaration: "constant", name: ::String, :type => Types::t, location: Location::t, comment: Comment::t }
-
-  type definitions_global = { declaration: "global", name: ::String, :type => Types::t, location: Location::t, comment: Comment::t }
-
   type definitions_moduletypeparam = { name: ::String, variance: "covariant" | "contravariant" | "invariant", skip_validation: bool }
+
+  type definitions_alias = { declaration: "alias", name: ::String, type_params: { params: ::Array[definitions_moduletypeparam] }, type: Types::t, annotations: ::Array[Annotation::t], location: Location::t, comment: Comment::t }
+
+  type definitions_constant = { declaration: "constant", name: ::String, type: Types::t, location: Location::t, comment: Comment::t }
+
+  type definitions_global = { declaration: "global", name: ::String, type: Types::t, location: Location::t, comment: Comment::t }
 
   type definitions_moduleself = { name: ::String, args: ::Array[Types::t] }
 
@@ -63,7 +64,7 @@ module Decls
 
   type definitions_classmember = Members::definitions_methoddefinition | Members::definitions_variable | Members::definitions_include | Members::definitions_extend | Members::definitions_prepend | Members::definitions_attribute | Members::definitions_visibility | Members::definitions_alias | definitions_alias | definitions_constant | definitions_class | definitions_module | definitions_interface
 
-  type definitions_class = { declaration: "class", name: ::String, type_params: { params: ::Array[definitions_moduletypeparam] }, members: ::Array[definitions_classmember], :super_class => nil | { name: ::String, args: ::Array[Types::t] }, annotations: ::Array[Annotation::t], comment: Comment::t, location: Location::t }
+  type definitions_class = { declaration: "class", name: ::String, type_params: { params: ::Array[definitions_moduletypeparam] }, members: ::Array[definitions_classmember], super_class: nil | { name: ::String, args: ::Array[Types::t] }, annotations: ::Array[Annotation::t], comment: Comment::t, location: Location::t }
 
   type t = definitions_alias | definitions_constant | definitions_global | definitions_class | definitions_module | definitions_interface
 end
@@ -73,45 +74,45 @@ module Location
 
   type definitions_buffer = { name: ::String | nil }
 
-  type definitions_location = { start: definitions_point, :end => definitions_point, buffer: definitions_buffer }
+  type definitions_location = { start: definitions_point, end: definitions_point, buffer: definitions_buffer }
 
   type t = definitions_location | nil
 end
 
 module Types
-  type definitions_base = { :class => "bool" | "void" | "untyped" | "nil" | "top" | "bot" | "self" | "instance" | "class", location: Location::t }
+  type definitions_base = { class: "bool" | "void" | "untyped" | "nil" | "top" | "bot" | "self" | "instance" | "class", location: Location::t }
 
-  type definitions_variable = { :class => "variable", name: ::String, location: Location::t }
+  type definitions_variable = { class: "variable", name: ::String, location: Location::t }
 
-  type definitions_classinstance = { :class => "class_instance", name: ::String, args: ::Array[t], location: Location::t }
+  type definitions_classinstance = { class: "class_instance", name: ::String, args: ::Array[t], location: Location::t }
 
-  type definitions_classsingleton = { :class => "class_singleton", name: ::String, location: Location::t }
+  type definitions_classsingleton = { class: "class_singleton", name: ::String, location: Location::t }
 
-  type definitions_interface = { :class => "interface", name: ::String, args: ::Array[t], location: Location::t }
+  type definitions_interface = { class: "interface", name: ::String, args: ::Array[t], location: Location::t }
 
-  type definitions_alias = { :class => "alias", name: ::String, location: Location::t }
+  type definitions_alias = { class: "alias", name: ::String, args: ::Array[t], location: Location::t }
 
-  type definitions_tuple = { :class => "tuple", types: ::Array[t], location: Location::t }
+  type definitions_tuple = { class: "tuple", types: ::Array[t], location: Location::t }
 
-  type definitions_record = { :class => "record", fields: ::Hash[::String, t], location: Location::t }
+  type definitions_record = { class: "record", fields: ::Hash[::String, t], location: Location::t }
 
-  type definitions_union = { :class => "union", types: ::Array[t], location: Location::t }
+  type definitions_union = { class: "union", types: ::Array[t], location: Location::t }
 
-  type definitions_intersection = { :class => "intersection", types: ::Array[t], location: Location::t }
+  type definitions_intersection = { class: "intersection", types: ::Array[t], location: Location::t }
 
-  type definitions_optional = { :class => "optional", :type => t, location: Location::t }
+  type definitions_optional = { class: "optional", type: t, location: Location::t }
 
-  type definitions_proc = { :class => "proc", :type => Function::t, location: Location::t }
+  type definitions_proc = { class: "proc", type: Function::t, location: Location::t }
 
-  type definitions_literal = { :class => "literal", literal: ::String, location: Location::t }
+  type definitions_literal = { class: "literal", literal: ::String, location: Location::t }
 
   type t = definitions_base | definitions_variable | definitions_classinstance | definitions_classsingleton | definitions_interface | definitions_alias | definitions_tuple | definitions_record | definitions_union | definitions_intersection | definitions_optional | definitions_proc | definitions_literal
 end
 
 module Function
-  type definitions_param = { :type => Types::t, name: ::String | nil }
+  type definitions_param = { type: Types::t, name: ::String | nil }
 
-  type t = { required_positionals: ::Array[definitions_param], optional_positionals: ::Array[definitions_param], rest_positionals: definitions_param | nil, trailing_positionals: ::Array[definitions_param], required_keywords: ::Hash[::String, definitions_param], optional_keywords: ::Hash[::String, definitions_param], rest_keywords: definitions_param | nil, :return_type => Types::t }
+  type t = { required_positionals: ::Array[definitions_param], optional_positionals: ::Array[definitions_param], rest_positionals: definitions_param | nil, trailing_positionals: ::Array[definitions_param], required_keywords: ::Hash[::String, definitions_param], optional_keywords: ::Hash[::String, definitions_param], rest_keywords: definitions_param | nil, return_type: Types::t }
 end
 
 module Annotation
@@ -125,15 +126,15 @@ module Comment
 end
 
 module MethodType
-  type definitions_block = { :type => Function::t, required: bool }
+  type definitions_block = { type: Function::t, required: bool }
 
-  type t = { type_params: ::Array[::String], :type => Function::t, block: definitions_block | nil, location: Location::t }
+  type t = { type_params: ::Array[::String], type: Function::t, block: definitions_block | nil, location: Location::t }
 end
 
 module Members
-  type definitions_methoddefinition = { member: "method_definition", kind: "instance" | "singleton" | "singleton_instance", types: ::Array[MethodType::t], comment: Comment::t, annotations: ::Array[Annotation::t], attributes: ::Array["incompatible"], location: Location::t, :overload => bool }
+  type definitions_methoddefinition = { member: "method_definition", kind: "instance" | "singleton" | "singleton_instance", types: ::Array[MethodType::t], comment: Comment::t, annotations: ::Array[Annotation::t], attributes: ::Array["incompatible"], location: Location::t, overload: bool }
 
-  type definitions_variable = { member: "instance_variable" | "class_instance_variable" | "class_variable", name: ::String, :type => Types::t, location: Location::t, comment: Comment::t }
+  type definitions_variable = { member: "instance_variable" | "class_instance_variable" | "class_variable", name: ::String, type: Types::t, location: Location::t, comment: Comment::t }
 
   type definitions_include = { member: "include", name: ::String, args: ::Array[Types::t], annotations: ::Array[Annotation::t], comment: Comment::t, location: Location::t }
 
@@ -141,7 +142,7 @@ module Members
 
   type definitions_prepend = { member: "prepend", name: ::String, args: ::Array[Types::t], annotations: ::Array[Annotation::t], comment: Comment::t, location: Location::t }
 
-  type definitions_attribute = { member: "attr_reader" | "attr_accessor" | "attr_writer", name: ::String, kind: "instance" | "singleton", :type => Types::t, ivar_name: ::String | nil | false, annotations: ::Array[Annotation::t], comment: Comment::t, location: Location::t }
+  type definitions_attribute = { member: "attr_reader" | "attr_accessor" | "attr_writer", name: ::String, kind: "instance" | "singleton", type: Types::t, ivar_name: ::String | nil | false, annotations: ::Array[Annotation::t], comment: Comment::t, location: Location::t }
 
   type definitions_visibility = { member: "public" | "private", location: Location::t }
 
@@ -162,7 +163,7 @@ module Location
 
   type definitions_buffer = { name: ::String | nil }
 
-  type definitions_location = { start: definitions_point, :end => definitions_point, buffer: definitions_buffer }
+  type definitions_location = { start: definitions_point, end: definitions_point, buffer: definitions_buffer }
 
   type t = definitions_location | nil
 end

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -6,7 +6,6 @@ class CLITest < Minitest::Test
   include RBSJsonSchema
 
   RBS_PATH = Pathname(Gem::Specification.find_by_name("rbs", RBS::VERSION).gem_dir).realpath
-  puts RBS_PATH
   SCHEMA_PATH = RBS_PATH + "schema"
 
   def stdout


### PR DESCRIPTION
Fixing a couple of validation issues

- I had a schema that had `anyOf` instead of `oneOf`.

- Extracted the `case ty` to its own function so that `"type": ["null", "string"]` works.

This is built on PR #3.